### PR TITLE
chore(release): v0.4.0 — CI hardening, SBOM, mypy, pre-commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2025-10-09
+
+⚙️ Maintenance & CI Hardening; SBOM; Type Checking
+
+This release focuses on build quality, supply-chain visibility, and developer experience.
+
+### Added
+- Security workflow now generates a CycloneDX SBOM (JSON artifact) for every push/PR
+- Security Scanning and SBOM badges in README
+- Pre-commit hooks for Ruff (lint + format) and mypy (src-only)
+
+### Changed
+- CI: Re-enabled mypy in tests workflow; type errors resolved across codebase
+- CI: Bandit runs made non-blocking; results displayed in Security Summary
+- CI: Guard workflow blocks built site artifacts (index.html, assets/, search/) on main
+- CI: GitHub Actions updated (actions/checkout v5, codecov-action v5, setup-uv v7)
+- Docs: CONTRIBUTING adds pre-commit instructions; SECURITY documents SBOM
+
+### Fixed
+- Security workflow SBOM flags corrected to use cyclonedx-py with `--output-format` and `--output-file`
+- Ruff formatting and import order across modules; exception chaining (B904) applied
+
+### Notes
+- No breaking API changes
+- Versioning adjusted to pre-1.0 scheme (0.4.0)
+
 ## [1.0.0] - 2025-10-09
 
 🎉 **Production Release: Mnemex v1.0.0**
@@ -144,4 +170,3 @@ MIT License - Full user control and transparency
 ## [0.2.0] - 2025-01-07
 
 - JSONL storage, LTM index, Git integration, and smart prompting docs.
-

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,5 +115,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 ---
 
 **Last Updated:** 2025-10-09
-**Current Version:** 1.0.0
-**Next Release:** 1.1.0 (Q1 2026 - Security & Stability)
+**Current Version:** 0.4.0
+**Next Release:** 0.5.0 (Q1 2026 - Security & Stability)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ We release patches for security vulnerabilities in the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
+| 0.4.x   | :white_check_mark: |
+| 0.3.x   | :white_check_mark: |
 | < 1.0   | :x:                |
 
 ## Reporting a Vulnerability

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mnemex"
-version = "1.0.0"
+version = "0.4.0"
 description = "Mnemex: Temporal memory management for AI assistants with human-like dynamics"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Pre-1.0 versioning: prepare v0.4.0.\n\n- pyproject: version 0.4.0\n- CHANGELOG: 0.4.0 entry (SBOM, mypy in CI, pre-commit hooks, ruff, guard)\n- SECURITY: supported versions 0.4.x / 0.3.x\n- ROADMAP: current 0.4.0, next 0.5.0\n\nContext: earlier 1.1.0 tag removed; this aligns with our plan to remain pre-1.0 until cross-platform/perf testing and API stability.\n\nAfter merge: tag v0.4.0 and publish release notes.