### PR TITLE
ci: fix Codecov v5 inputs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,11 @@ jobs:
       uses: codecov/codecov-action@v5
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
+        flags: unittests
+        name: codecov-ubuntu-py310
         fail_ci_if_error: false
+        verbose: true
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update Codecov action step to v5-compatible inputs:\n\n- Use 'files' instead of 'file'\n- Add flags and name for clarity\n- Keep fail_ci_if_error=false and enable verbose logs\n\nShould resolve recent Codecov upload failures while keeping Gate as the only required check.