### PR TITLE
fix(ci): add CNAME file to docs/ and fix mkdocs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,5 +46,5 @@ jobs:
         run: mkdocs build --strict
 
       - name: Deploy to GitHub Pages
-        # Include custom domain to preserve CNAME on each deploy
-        run: mkdocs gh-deploy --force --custom-domain mnemex.dev
+        # CNAME file in docs/ dir will be deployed automatically
+        run: mkdocs gh-deploy --force

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+mnemex.dev


### PR DESCRIPTION
## Problem
GitHub Pages custom domain kept getting reset after deployments.

Investigation revealed:
- Workflow used `mkdocs gh-deploy --custom-domain mnemex.dev` flag
- **This flag doesn't exist** in mkdocs, causing all deployments to fail
- Failed deployments left GitHub Pages API without custom domain configured
- Last successful deployment: 2 days ago (before the invalid flag was added)

## Solution

### 1. Added CNAME file to docs directory
- Created `docs/CNAME` with `mnemex.dev`
- MkDocs automatically copies this to gh-pages branch during deployment
- This is the standard mkdocs pattern for custom domains

### 2. Fixed workflow deployment command
- Removed invalid `--custom-domain` flag from workflow
- Changed to: `mkdocs gh-deploy --force`
- Workflow will now complete successfully

### 3. Configured GitHub Pages API
- Set custom domain via GitHub API: `gh api repos/.../pages -X PUT`
- Both CNAME file AND API setting are required for custom domains

## How Custom Domains Work in GitHub Pages

GitHub Pages requires **two things** for custom domains:
1. CNAME file in the deployed branch (handled by mkdocs from docs/CNAME)
2. GitHub Pages API setting (manually configured, persists across deployments)

## Testing

Once merged:
- Docs workflow will trigger on push to main
- MkDocs will deploy successfully with CNAME file
- Site will be available at https://mnemex.dev
- Custom domain will persist across future deployments

## References
- MkDocs docs: https://www.mkdocs.org/user-guide/deploying-your-docs/
- GitHub issue: https://github.com/mkdocs/mkdocs/issues/1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)