### PR TITLE
fix: Enable PyPI trusted publishing with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # Required for trusted publishing
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -25,5 +26,3 @@ jobs:
         run: python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the PyPI publishing workflow failure by enabling trusted publishing with OIDC.

## Changes

- Add `id-token: write` permission to publish workflow
- Remove `password` parameter (trusted publishing uses OIDC instead of API tokens)
- Fixes the `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variable error

## Why Trusted Publishing?

- **More secure** - No API tokens to manage or rotate
- **Recommended by PyPI** - Modern authentication method
- **Simpler** - No secrets configuration needed

## Setup Required

To complete the setup, configure the pending publisher on PyPI:

1. Go to https://pypi.org/manage/account/publishing/
2. Click "Add a new pending publisher"
3. Configure:
   - **PyPI Project Name:** `mnemex`
   - **Owner:** `simplemindedbot`
   - **Repository name:** `mnemex`
   - **Workflow name:** `publish.yml`
   - **Environment name:** (leave blank)

## References

- [PyPI Trusted Publishers Documentation](https://docs.pypi.org/trusted-publishers/)
- [GitHub OIDC Security Hardening](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)

## Testing

The workflow will be tested on the next tag push (e.g., `v0.5.1`).