### PR TITLE
Fix: Update tests to expect MCP-friendly auto-sanitization

### DIFF
--- a/tests/test_tools_save.py
+++ b/tests/test_tools_save.py
@@ -131,10 +131,13 @@ class TestSaveMemory:
         with pytest.raises(ValueError, match="tag.*exceeds maximum"):
             save_memory(content="Test", tags=[long_tag])
 
-    def test_save_invalid_tag_characters_fails(self):
-        """Test that tags with invalid characters fail validation."""
-        with pytest.raises(ValueError, match="tag.*invalid characters"):
-            save_memory(content="Test", tags=["invalid tag!"])
+    def test_save_invalid_tag_characters_sanitized(self, temp_storage):
+        """Test that tags with invalid characters are auto-sanitized (MCP-friendly)."""
+        result = save_memory(content="Test", tags=["invalid tag!"])
+        assert result["success"] is True
+        # Verify memory was saved with sanitized tag ("invalid tag!" -> "invalid_tag")
+        memory = temp_storage.get_memory(result["memory_id"])
+        assert "invalid_tag" in memory.meta.tags
 
     def test_save_too_many_entities_fails(self):
         """Test that too many entities fails validation."""

--- a/tests/test_tools_search.py
+++ b/tests/test_tools_search.py
@@ -261,10 +261,12 @@ class TestSearchMemory:
         with pytest.raises(ValueError, match="tags.*exceeds maximum"):
             search_memory(tags=too_many_tags)
 
-    def test_search_invalid_tag_fails(self):
-        """Test that invalid tag characters fail."""
-        with pytest.raises(ValueError, match="tag.*invalid characters"):
-            search_memory(tags=["invalid tag!"])
+    def test_search_invalid_tag_sanitized(self, temp_storage):
+        """Test that invalid tag characters are auto-sanitized (MCP-friendly)."""
+        # Should succeed with sanitized tag ("invalid tag!" -> "invalid_tag")
+        result = search_memory(tags=["invalid tag!"])
+        assert result["success"] is True
+        # Search should complete without error (even if no results found)
 
     def test_search_invalid_top_k_fails(self):
         """Test that invalid top_k values fail."""


### PR DESCRIPTION
## Summary
Fixes failing CI tests by updating 3 test cases to expect auto-sanitization behavior instead of ValueError.

## Problem
PR #61 merged validators with `auto_sanitize=True` as default, but tests still expected strict validation with ValueError. This caused 3 test failures in CI.

## Solution
Updated tests to match the MCP-friendly design:
- `test_save_invalid_tag_characters_sanitized`: Verifies tag is sanitized ("invalid tag!" → "invalid_tag") and saved successfully
- `test_search_invalid_tag_sanitized`: Verifies search succeeds with auto-sanitized tags
- `test_invalid_tag_sanitized`: Verifies unified search succeeds with auto-sanitized tags

## Rationale
As an MCP server, auto-sanitization prevents:
- LLM retry loops when tags have minor formatting issues
- Unnecessary context/token burn from repeated failed attempts
- User friction from strict validation errors

For MCP use cases, **user-friendliness > strict validation**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>