### PR TITLE
chore: Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cortexgraph"
-version = "0.1.0"
+version = "0.2.1"
 description = "CortexGraph: Temporal memory management for AI assistants with human-like dynamics"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cortexgraph/__init__.py
+++ b/src/cortexgraph/__init__.py
@@ -5,4 +5,4 @@ A Model Context Protocol (MCP) server that provides ephemeral, local memory
 with temporal decay, reinforcement, and automatic promotion to long‑term storage.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
Version bump to 0.2.1 after cortexgraph rebranding.

This PR contains:
- Version update in pyproject.toml
- Version update in __init__.py

All tests passing ✓